### PR TITLE
Fix key for themes in volt.toml

### DIFF
--- a/volt.toml
+++ b/volt.toml
@@ -4,4 +4,4 @@ description = "The Iconic Atom One Theme"
 version = "0.1.0"
 author = "Lapce"
 repository = "https://github.com/lapce/atom-one"
-themes = ["one-dark.toml", "one-light.toml"]
+color-themes = ["one-dark.toml", "one-light.toml"]


### PR DESCRIPTION
Change keyword for themes from `themes` to `color-themes` in volt.toml.

Fixes the `not a valid plugin` error which comes due to invalid keyword. #1 